### PR TITLE
Upgrade changelog-generator to 0.0.12

### DIFF
--- a/src/main/java/io/micrometer/release/single/ChangelogGeneratorDownloader.java
+++ b/src/main/java/io/micrometer/release/single/ChangelogGeneratorDownloader.java
@@ -34,7 +34,7 @@ class ChangelogGeneratorDownloader {
 
     private static final String CHANGELOG_GENERATOR_JAR = "github-changelog-generator.jar";
 
-    private static final String DEFAULT_CHANGELOG_GENERATOR_VERSION = "0.0.11";
+    private static final String DEFAULT_CHANGELOG_GENERATOR_VERSION = "0.0.12";
 
     static final String CHANGELOG_GENERATOR_URL = "https://github.com/spring-io/github-changelog-generator/releases/download/v%s/github-changelog-generator.jar";
 


### PR DESCRIPTION
Fixes an issue we're having with an error response from the GitHub API when generating the release notes for a milestone with enough issues to have more than one page.