### PR TITLE
Fix changelog generator config

### DIFF
--- a/src/main/java/io/micrometer/release/single/ChangelogGenerator.java
+++ b/src/main/java/io/micrometer/release/single/ChangelogGenerator.java
@@ -27,7 +27,7 @@ class ChangelogGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(ChangelogGenerator.class);
 
-    static final String INPUT_FILE = "changelog.md";
+    static final String DEFAULT_OUTPUT_FILE = "changelog.md";
 
     static final String GITHUB_API_URL = "https://api.github.com";
 
@@ -42,7 +42,7 @@ class ChangelogGenerator {
     public ChangelogGenerator(ProcessRunner processRunner) {
         this.githubApi = GITHUB_API_URL;
         this.githubToken = Input.getGhToken();
-        this.outputFile = new File(INPUT_FILE);
+        this.outputFile = new File(DEFAULT_OUTPUT_FILE);
         this.processRunner = processRunner;
     }
 
@@ -56,9 +56,27 @@ class ChangelogGenerator {
 
     File generateChangelog(String githubRefName, String githubOrgRepo, File jarPath) {
         log.info("Generating changelog...");
-        processRunner.run(getJava(), "-jar", jarPath.getAbsolutePath(), githubRefName.replace("v", ""),
-                outputFile.getAbsolutePath(), "--changelog.repository=" + githubOrgRepo,
-                "--github.api-url=" + githubApi, "--github.token=" + githubToken);
+        // @formatter:off
+        processRunner.run(getJava(), "-jar", jarPath.getAbsolutePath(),
+            githubRefName.replace("v", ""),
+            outputFile.getAbsolutePath(),
+            "--changelog.repository=" + githubOrgRepo,
+            "--changelog.contributors.exclude.names=shakuzen,jonatan-ivanov",
+            "--changelog.sections[0].title=:warning: Noteworthy",
+            "--changelog.sections[0].labels=release notes",
+            "--changelog.sections[1].title=:star: New Features",
+            "--changelog.sections[1].labels=enhancement",
+            "--changelog.sections[2].title=:lady_beetle: Bug Fixes",
+            "--changelog.sections[2].labels=bug, regression",
+            "--changelog.sections[3].title=:notebook_with_decorative_cover: Documentation",
+            "--changelog.sections[3].labels=doc-update, documentation",
+            "--changelog.sections[4].title=:hammer: Dependency Upgrades",
+            "--changelog.sections[4].labels=dependency-upgrade, dependencies",
+//            "--changelog.sections[5].title=:memo: Tasks",
+//            "--changelog.sections[5].labels=task",
+            "--github.api-url=" + githubApi,
+            "--github.token=" + githubToken);
+        // @formatter:on
         return outputFile;
     }
 

--- a/src/test/resources/generator/micrometer.md
+++ b/src/test/resources/generator/micrometer.md
@@ -1,3 +1,11 @@
+## :notebook_with_decorative_cover: Documentation
+
+- Add docs for multiple MeterTag annotations [#5641](https://github.com/micrometer-metrics/micrometer/pull/5641)
+- Add docs for `@MeterTag` for `@Counted` [#5640](https://github.com/micrometer-metrics/micrometer/pull/5640)
+- Add docs for JvmThreadDeadlockMetrics [#5614](https://github.com/micrometer-metrics/micrometer/pull/5614)
+- Add docs for ForkJoinPool parallelism and pool size metrics [#5611](https://github.com/micrometer-metrics/micrometer/pull/5611)
+- Add docs for VirtualThreadMetrics [#5610](https://github.com/micrometer-metrics/micrometer/pull/5610)
+
 ## :hammer: Dependency Upgrades
 
 - Bump io.prometheus:prometheus-metrics-bom from 1.3.1 to 1.3.3 [#5649](https://github.com/micrometer-metrics/micrometer/pull/5649)
@@ -13,4 +21,4 @@
 
 Thank you to all the contributors who worked on this release:
 
-@izeye, @jonatan-ivanov, and @shakuzen
+@izeye

--- a/src/test/resources/processor/micrometer-1.13.9-output.md
+++ b/src/test/resources/processor/micrometer-1.13.9-output.md
@@ -13,4 +13,4 @@
 
 Thank you to all the contributors who worked on this release:
 
-@izeye and @jonatan-ivanov
+@izeye

--- a/src/test/resources/processor/micrometer-1.14.0-output.md
+++ b/src/test/resources/processor/micrometer-1.14.0-output.md
@@ -5,6 +5,14 @@
 - Warn about gauge re-registration [#5688](https://github.com/micrometer-metrics/micrometer/pull/5688)
 - `executor.queued` metrics of ForkJoinPool does not include queued submissions [#5650](https://github.com/micrometer-metrics/micrometer/issues/5650)
 
+## :notebook_with_decorative_cover: Documentation
+
+- Add docs for ForkJoinPool parallelism and pool size metrics [#5611](https://github.com/micrometer-metrics/micrometer/pull/5611)
+- Add docs for JvmThreadDeadlockMetrics [#5614](https://github.com/micrometer-metrics/micrometer/pull/5614)
+- Add docs for VirtualThreadMetrics [#5610](https://github.com/micrometer-metrics/micrometer/pull/5610)
+- Add docs for `@MeterTag` for `@Counted` [#5640](https://github.com/micrometer-metrics/micrometer/pull/5640)
+- Add docs for multiple MeterTag annotations [#5641](https://github.com/micrometer-metrics/micrometer/pull/5641)
+
 ## :hammer: Dependency Upgrades
 
 - Bump com.google.auth:google-auth-library-oauth2-http from 1.28.0 to 1.29.0 [#5634](https://github.com/micrometer-metrics/micrometer/pull/5634)
@@ -20,4 +28,4 @@
 
 Thank you to all the contributors who worked on this release:
 
-@izeye, @jonatan-ivanov, and @shakuzen
+@izeye


### PR DESCRIPTION
We used to use something like this config file to generate release notes:
```yaml
changelog:
    repository: micrometer-metrics/micrometer
    sections:
        - title: ':warning: Noteworthy'
          labels: [ 'release notes' ]
          group: 'noteworthy'
        - title: ':star: New Features'
          labels: [ 'enhancement' ]
        - title: ':lady_beetle: Bug Fixes'
          labels: [ 'bug', 'regression' ]
        - title: ':notebook_with_decorative_cover: Documentation'
          labels: [ 'doc-update', 'documentation' ]
        - title: ':hammer: Dependency Upgrades'
          labels: [ 'dependency-upgrade', 'dependencies' ]
        - title: ':memo: Tasks'
          labels: [ 'type: task' ]
    contributors.exclude.names: [ 'shakuzen', 'jonatan-ivanov']
```

The current `ChangelogGenerator` does not set config like this and uses the [default](https://github.com/spring-io/github-changelog-generator?tab=readme-ov-file#customizing-sections) that has the following differences:
- No `release notes`/"Noteworthy" section (the changelog generator does not have the concept of it)
- Missing "Documentation" section since our label is `doc-update` while the default is `documentation`
- Missing "Dependency Upgrades" since the default is `dependency-upgrade` while dependabot applies `dependencies`
- (Missing "Tasks", not sure if this is an issue)
- Contributors are not excluded

The most pressing is the missing "Noteworthy"/`release notes` section since that's usually the most important part of the release notes.